### PR TITLE
fix bug with duplicate

### DIFF
--- a/force-app/main/default/classes/CRM_JournalUtilities.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities.cls
@@ -56,33 +56,27 @@ public class CRM_JournalUtilities {
             // Status 409 is only used when the externalReference we provided for the request has already been used
             if (httpResp.getStatusCode() == 409) {
                 List<Journal_Entry__c> existingJEntries = [
-                    SELECT CRM_Thread__c, CRM_Conversation_Note__c
+                    SELECT Id
                     FROM Journal_Entry__c
                     WHERE Journal_Entry_Id__c = :resp.journalpostId
                     LIMIT 1
                 ];
-                resp.duplicate =
-                    existingJEntries.size() > 0 &&
-                    (existingJEntries[0].CRM_Thread__c == referenceId ||
-                    existingJEntries[0].CRM_Conversation_Note__c == referenceId);
+                // Check if same Journal Entry record - if true then it's actually a duplicate
+                resp.duplicate = existingJEntries.size() > 0 && existingJEntries[0].Id == referenceId;
             }
         } else {
+            LoggerUtility logger = new LoggerUtility('Journal');
+            SObject objectRef = String.isNotBlank(referenceId)
+                ? referenceId.getSobjectType().newSObject(referenceId)
+                : null;
+            logger.httpError('Error posting journal entry', httpResp, objectRef, CRM_ApplicationDomain.Domain.NKS);
+            String errorRef = logger.peek().UUID__c;
+            logger.publish();
             resp.success = false;
-            handleLogging(httpResp, referenceId, resp);
+            resp.errorMessage = errorRef;
         }
 
         return resp;
-    }
-
-    private static void handleLogging(HttpResponse httpResp, Id referenceId, UtilityResponse resp) {
-        LoggerUtility logger = new LoggerUtility('Journal');
-        SObject objectRef = String.isNotBlank(referenceId)
-            ? referenceId.getSobjectType().newSObject(referenceId)
-            : null;
-        logger.httpError('Error posting journal entry', httpResp, objectRef, CRM_ApplicationDomain.Domain.NKS);
-        String errorRef = logger.peek().UUID__c;
-        logger.publish();
-        resp.errorMessage = errorRef;
     }
 
     /**

--- a/force-app/main/default/classes/CRM_JournalUtilities.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities.cls
@@ -42,6 +42,7 @@ public class CRM_JournalUtilities {
         CRM_JournalService service = new CRM_JournalService();
         UtilityResponse resp = new UtilityResponse();
 
+        //Removed BID specific handling on second param as a results of FAGSYSTEM-189315
         HttpResponse httpResp = service.postJournal(journalRequest, true, navIdent);
 
         // Handle Success or Partial Success Responses

--- a/force-app/main/default/classes/CRM_JournalUtilities.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities.cls
@@ -42,63 +42,47 @@ public class CRM_JournalUtilities {
         CRM_JournalService service = new CRM_JournalService();
         UtilityResponse resp = new UtilityResponse();
 
-        Boolean complete = true; //Removed BID specific handling as a results of FAGSYSTEM-189315
-        HttpResponse httpResp = service.postJournal(journalRequest, complete, navIdent);
-        Integer statusCode = httpResp.getStatusCode();
+        HttpResponse httpResp = service.postJournal(journalRequest, true, navIdent);
 
-        if (statusCode == 200 || statusCode == 201) {
+        // Handle Success or Partial Success Responses
+        if (httpResp.getStatusCode() == 200 || httpResp.getStatusCode() == 201 || httpResp.getStatusCode() == 409) {
+            Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(httpResp.getBody());
             resp.success = true;
-            Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(httpResp.getBody());
             resp.journalpostId = (String) responseMap.get('journalpostId');
-            Boolean journalCompleted = (Boolean) responseMap.get('journalpostferdigstilt');
-            resp.journalPostStatus = journalCompleted ? 'Completed' : 'In Progress';
-        } else if (statusCode == 409) {
-            // Status 409 is only used when the externalReference we provided for the request has already been used
-            Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(httpResp.getBody());
-            String journalExtId = (String) responseMap.get('journalpostId');
-            List<Journal_entry__c> existingJEntries = [
-                SELECT Id
-                FROM Journal_entry__c
-                WHERE Journal_entry_id__c = :journalExtId
-                LIMIT 1
-            ];
-            if (existingJEntries.size() > 0) {
-                resp.success = true;
-                resp.duplicate = existingJEntries[0].Id != referenceId;
-                Boolean journalCompleted = (Boolean) responseMap.get('journalpostferdigstilt');
-                resp.journalPostStatus = journalCompleted ? 'Completed' : 'In Progress';
-            } else {
-                resp.success = false;
-                LoggerUtility logger = new LoggerUtility('Journal');
-                SObject objectRef = String.isNotBlank(referenceId)
-                    ? referenceId.getSobjectType().newSObject(referenceId)
-                    : null;
+            resp.journalPostStatus = ((Boolean) responseMap.get('journalpostferdigstilt'))
+                ? 'Completed'
+                : 'In Progress';
 
-                logger.httpError(
-                    'Error posting journal entry, got conflict but found no existing journal post',
-                    httpResp,
-                    objectRef,
-                    CRM_ApplicationDomain.Domain.NKS
-                );
-                String errorRef = logger.peek().UUID__c; //Unique error reference for troubleshooting
-                logger.publish();
-                resp.errorMessage = errorRef;
+            // Status 409 is only used when the externalReference we provided for the request has already been used
+            if (httpResp.getStatusCode() == 409) {
+                List<Journal_Entry__c> existingJEntries = [
+                    SELECT CRM_Thread__c, CRM_Conversation_Note__c
+                    FROM Journal_Entry__c
+                    WHERE Journal_entry_id__c = :resp.journalpostId
+                    LIMIT 1
+                ];
+                resp.duplicate =
+                    existingJEntries.size() > 0 &&
+                    (existingJEntries[0].CRM_Thread__c == referenceId ||
+                    existingJEntries[0].CRM_Conversation_Note__c == referenceId);
             }
         } else {
             resp.success = false;
-            //Creates a log entry for troubleshooting
-            LoggerUtility logger = new LoggerUtility('Journal');
-            SObject objectRef = String.isNotBlank(referenceId)
-                ? referenceId.getSobjectType().newSObject(referenceId)
-                : null;
-
-            logger.httpError('Error posting journal entry', httpResp, objectRef, CRM_ApplicationDomain.Domain.NKS);
-            String errorRef = logger.peek().UUID__c; //Unique error reference for troubleshooting
-            logger.publish();
-            resp.errorMessage = errorRef;
+            handleLogging(httpResp, referenceId, resp);
         }
 
         return resp;
+    }
+
+    private static void handleLogging(HttpResponse httpResp, Id referenceId, UtilityResponse resp) {
+        LoggerUtility logger = new LoggerUtility('Journal');
+        SObject objectRef = String.isNotBlank(referenceId)
+            ? referenceId.getSobjectType().newSObject(referenceId)
+            : null;
+        logger.httpError('Error posting journal entry', httpResp, objectRef, CRM_ApplicationDomain.Domain.NKS);
+        String errorRef = logger.peek().UUID__c;
+        logger.publish();
+        resp.errorMessage = errorRef;
     }
 
     /**

--- a/force-app/main/default/classes/CRM_JournalUtilities.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities.cls
@@ -52,18 +52,8 @@ public class CRM_JournalUtilities {
             resp.journalPostStatus = ((Boolean) responseMap.get('journalpostferdigstilt'))
                 ? 'Completed'
                 : 'In Progress';
-
             // Status 409 is only used when the externalReference we provided for the request has already been used
-            if (httpResp.getStatusCode() == 409) {
-                List<Journal_Entry__c> existingJEntries = [
-                    SELECT Id
-                    FROM Journal_Entry__c
-                    WHERE Journal_Entry_Id__c = :resp.journalpostId
-                    LIMIT 1
-                ];
-                // Check if same Journal Entry record - if true then it's actually a duplicate
-                resp.duplicate = existingJEntries.size() > 0 && existingJEntries[0].Id == referenceId;
-            }
+            resp.duplicate = httpResp.getStatusCode() == 409;
         } else {
             LoggerUtility logger = new LoggerUtility('Journal');
             SObject objectRef = String.isNotBlank(referenceId)

--- a/force-app/main/default/classes/CRM_JournalUtilities.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities.cls
@@ -58,7 +58,7 @@ public class CRM_JournalUtilities {
                 List<Journal_Entry__c> existingJEntries = [
                     SELECT CRM_Thread__c, CRM_Conversation_Note__c
                     FROM Journal_Entry__c
-                    WHERE Journal_entry_id__c = :resp.journalpostId
+                    WHERE Journal_Entry_Id__c = :resp.journalpostId
                     LIMIT 1
                 ];
                 resp.duplicate =

--- a/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
@@ -83,7 +83,6 @@ public class CRM_JournalUtilities_Test {
             null,
             journalRequest
         );
-        utilRequest.referenceId = [SELECT Id FROM Journal_Entry__c LIMIT 1].Id;
 
         Test.startTest();
         List<CRM_JournalUtilities.UtilityResponse> responses = CRM_JournalUtilities.handleRequest(

--- a/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
@@ -95,32 +95,6 @@ public class CRM_JournalUtilities_Test {
     }
 
     @isTest
-    static void testPostJournalDuplicateButFoundNoExistingJEntries() {
-        CRM_JournalEntryWrapper journalRequest = new CRM_JournalEntryWrapper();
-
-        Test.setMock(
-            HttpCalloutMock.class,
-            new SingleRequestMock(409, 'Conflict', '{"journalpostId": "3456787", "journalpostferdigstilt": true}', null)
-        );
-
-        CRM_JournalUtilities.utilityRequest utilRequest = new CRM_JournalUtilities.utilityRequest(
-            'POST_JOURNAL',
-            null,
-            journalRequest
-        );
-        utilRequest.referenceId = [SELECT Id FROM Journal_Entry__c LIMIT 1].Id;
-
-        Test.startTest();
-        List<CRM_JournalUtilities.UtilityResponse> responses = CRM_JournalUtilities.handleRequest(
-            new List<CRM_JournalUtilities.utilityRequest>{ utilRequest }
-        );
-        Test.stopTest();
-
-        Assert.isTrue(responses[0].success, 'The response was not accurately set as success');
-        Assert.isFalse(responses[0].duplicate, 'Duplicate was incorrectly set to true');
-    }
-
-    @isTest
     static void testPostJournalError() {
         CRM_JournalEntryWrapper journalRequest = new CRM_JournalEntryWrapper();
 

--- a/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
@@ -2,7 +2,9 @@
 public class CRM_JournalUtilities_Test {
     @TestSetup
     static void makeData() {
-        insert new Journal_Entry__c(Journal_Entry_ID__c = '1234567');
+        Thread__c thread = new Thread__c();
+        insert new Thread__c();
+        insert new Journal_Entry__c(Journal_Entry_ID__c = '1234567', CRM_Thread__c = thread.Id);
     }
 
     @isTest
@@ -83,23 +85,19 @@ public class CRM_JournalUtilities_Test {
             null,
             journalRequest
         );
+        utilRequest.referenceId = [SELECT CRM_Thread__c FROM Journal_Entry__c LIMIT 1].CRM_Thread__c;
 
         Test.startTest();
-        String journalPostId = CRM_JournalUtilities.handleRequest(
-                new List<CRM_JournalUtilities.utilityRequest>{ utilRequest }
-            )[0]
-            .journalpostId;
-        Boolean duplicate = CRM_JournalUtilities.handleRequest(
-                new List<CRM_JournalUtilities.utilityRequest>{ utilRequest }
-            )[0]
-            .duplicate;
+        List<CRM_JournalUtilities.UtilityResponse> responses = CRM_JournalUtilities.handleRequest(
+            new List<CRM_JournalUtilities.utilityRequest>{ utilRequest }
+        );
         Test.stopTest();
 
-        Assert.isTrue(duplicate, 'The journal was not accurately marked as duplicate');
+        Assert.isTrue(responses[0].duplicate, 'The journal was not accurately marked as duplicate');
     }
 
     @isTest
-    static void testPostJournalDuplicateCrash() {
+    static void testPostJournalDuplicateButFoundNoExistingJEntries() {
         CRM_JournalEntryWrapper journalRequest = new CRM_JournalEntryWrapper();
 
         Test.setMock(
@@ -112,20 +110,16 @@ public class CRM_JournalUtilities_Test {
             null,
             journalRequest
         );
+        utilRequest.referenceId = [SELECT CRM_Thread__c FROM Journal_Entry__c LIMIT 1].CRM_Thread__c;
 
         Test.startTest();
-        String errorMessage = CRM_JournalUtilities.handleRequest(
-                new List<CRM_JournalUtilities.utilityRequest>{ utilRequest }
-            )[0]
-            .errorMessage;
-        Boolean success = CRM_JournalUtilities.handleRequest(
-                new List<CRM_JournalUtilities.utilityRequest>{ utilRequest }
-            )[0]
-            .success;
+        List<CRM_JournalUtilities.UtilityResponse> responses = CRM_JournalUtilities.handleRequest(
+            new List<CRM_JournalUtilities.utilityRequest>{ utilRequest }
+        );
         Test.stopTest();
 
-        Assert.isNotNull(errorMessage, 'Error was not defined');
-        Assert.isFalse(success, 'The request returned success when there was no duplicate entry in SF');
+        Assert.isTrue(responses[0].success, 'The response was not accurately set as success');
+        Assert.isFalse(responses[0].duplicate, 'Duplicate was incorrectly set to true');
     }
 
     @isTest

--- a/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
+++ b/force-app/main/default/classes/CRM_JournalUtilities_Test.cls
@@ -2,9 +2,7 @@
 public class CRM_JournalUtilities_Test {
     @TestSetup
     static void makeData() {
-        Thread__c thread = new Thread__c();
-        insert new Thread__c();
-        insert new Journal_Entry__c(Journal_Entry_ID__c = '1234567', CRM_Thread__c = thread.Id);
+        insert new Journal_Entry__c(Journal_Entry_ID__c = '1234567');
     }
 
     @isTest
@@ -85,7 +83,7 @@ public class CRM_JournalUtilities_Test {
             null,
             journalRequest
         );
-        utilRequest.referenceId = [SELECT CRM_Thread__c FROM Journal_Entry__c LIMIT 1].CRM_Thread__c;
+        utilRequest.referenceId = [SELECT Id FROM Journal_Entry__c LIMIT 1].Id;
 
         Test.startTest();
         List<CRM_JournalUtilities.UtilityResponse> responses = CRM_JournalUtilities.handleRequest(
@@ -110,7 +108,7 @@ public class CRM_JournalUtilities_Test {
             null,
             journalRequest
         );
-        utilRequest.referenceId = [SELECT CRM_Thread__c FROM Journal_Entry__c LIMIT 1].CRM_Thread__c;
+        utilRequest.referenceId = [SELECT Id FROM Journal_Entry__c LIMIT 1].Id;
 
         Test.startTest();
         List<CRM_JournalUtilities.UtilityResponse> responses = CRM_JournalUtilities.handleRequest(


### PR DESCRIPTION
Journal post id is an external id field. Therefore, duplicates in Salesforce is impossible => Set all duplicate responses to duplicate status.